### PR TITLE
feat: pass options prop to provider

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -25,8 +25,8 @@ const keyboardEvents: Record<'show' | 'hide', KeyboardEventName> = Platform.sele
   },
 });
 
-const AlertsProvider: React.FC = ({ children }) => {
-  const [state, dispatch] = useReducer(reducer, initialState);
+const AlertsProvider: React.FC<AlertsProviderProps> = ({ children, options }) => {
+  const [state, dispatch] = useReducer(reducer, {...initialState, ...(options && { options })});
   const [value, setValue] = useState('');
   const [password, setPassword] = useState('');
 
@@ -336,6 +336,11 @@ const AlertsProvider: React.FC = ({ children }) => {
               {
                 ...(state.options.maxWidth && {
                   maxWidth: state.options.width ?? state.options.maxWidth,
+                }),
+              },
+              {
+                ...(state.options.minWidth && {
+                  minWidth: state.options.width ?? state.options.minWidth,
                 }),
               },
             ]}

--- a/src/type.ts
+++ b/src/type.ts
@@ -21,6 +21,7 @@ export interface AlertsOptions {
   keyboardAppearance?: 'default' | 'dark' | 'light';
   width?: string | number;
   /** maxWidth is very useful for Web */
+  minWidth?: string | number;
   maxWidth?: string | number;
 }
 
@@ -106,4 +107,8 @@ type AlertsType = 'ALERT' | 'PROMPT' | 'DISMISS';
 export interface AlertAction {
   type: AlertsType;
   payload: Partial<AlertsState>;
+}
+
+export interface AlertsProviderProps {
+  options?: AlertsOptions
 }


### PR DESCRIPTION
This feature request has following changes

1. pass `options` prop to `AlertsProvider` to set initial options
2. add `minWidth` to `AlertsOptions`